### PR TITLE
Disable turbolinks for maps

### DIFF
--- a/app/helpers/gobierto_budgets/application_helper.rb
+++ b/app/helpers/gobierto_budgets/application_helper.rb
@@ -170,6 +170,7 @@ module GobiertoBudgets
       attrs << %Q{data-kind="#{@kind || 'expense'}"}
       attrs << %Q{data-area="#{@area_name || 'economic'}"}
       attrs << %Q{data-action="#{action_name}"}
+      attrs << %Q{data-no-turbolink="true"} if action_name == 'map'
       attrs.join(' ').html_safe
     end
 

--- a/app/views/layouts/gobierto_budgets_application.html.erb
+++ b/app/views/layouts/gobierto_budgets_application.html.erb
@@ -72,6 +72,7 @@
           <li><%= link_to t('.compare'), gobierto_budgets_compare_path , class: class_if('selected', current_page?(gobierto_budgets_compare_path) || action_name == 'compare')%></li>
           <li><%= link_to t('.rankings'), gobierto_budgets_ranking_path , class: class_if('selected', current_page?(gobierto_budgets_ranking_path) || action_name == 'ranking')%></li>
           <li><%= link_to t('.services'), gobierto_budgets_about_path(anchor: 'municipalities') , class: class_if('selected', current_page?(gobierto_budgets_about_path))%></li>
+          <li><%= link_to t('.maps'), gobierto_budgets_map_path(year: Date.today.year), class: class_if('selected', current_page?(gobierto_budgets_map_path(Date.today.year))), data: {no_turbolink: true} %></li>
         </ul>
       </menu>
 

--- a/config/locales/views/layouts/ca.yml
+++ b/config/locales/views/layouts/ca.yml
@@ -23,3 +23,4 @@ ca:
       privacy: Política de privacitat
       cookies: Política de galetes
       maps: Mapes
+      local_budgets: Pressupostos Municipals

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -23,3 +23,4 @@ en:
       privacy: Privacy policy
       cookies: Cookies policy
       maps: Maps
+      local_budgets: Local budgets

--- a/config/locales/views/layouts/es.yml
+++ b/config/locales/views/layouts/es.yml
@@ -23,3 +23,4 @@ es:
       privacy: Política de privacidad
       cookies: Política de cookies
       maps: Mapas
+      local_budgets: Presupuestos Municipales


### PR DESCRIPTION
This PR disables turbolinks in the maps page to load Carto assets just in this single page.