### PR TITLE
Missing translation autocomplete

### DIFF
--- a/app/assets/javascripts/autocomplete_settings.js
+++ b/app/assets/javascripts/autocomplete_settings.js
@@ -1,11 +1,13 @@
-var AUTOCOMPLETE_DEFAULTS = {
-  dataType: 'json',
-  minChars: 3,
-  showNoSuggestionNotice: true,
-  noSuggestionNotice: 'Lo sentimos, pero no hay resultados.',
-  preserveInput: true,
-  autoSelectFirst: true,
-  triggerSelectOnValidInput: false,
-  preventBadQueries: false,
-  tabDisabled: true
+var AUTOCOMPLETE_DEFAULTS = function(){
+  return {
+    dataType: 'json',
+    minChars: 3,
+    showNoSuggestionNotice: true,
+    noSuggestionNotice: I18n.t('layout.autocomplete_no_results'),
+    preserveInput: true,
+    autoSelectFirst: true,
+    triggerSelectOnValidInput: false,
+    preventBadQueries: false,
+    tabDisabled: true
+  };
 };

--- a/app/assets/javascripts/gobierto_budgets/compare.js
+++ b/app/assets/javascripts/gobierto_budgets/compare.js
@@ -17,7 +17,7 @@ $(function () {
     groupBy: 'category'
   }
 
-  $('#add_place').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, addPlaceOptions));
+  $('#add_place').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), addPlaceOptions));
 
   function compareUrl(list) {
     var slugs = $.map(list, function(place, i) {

--- a/app/assets/javascripts/gobierto_budgets/ui.js
+++ b/app/assets/javascripts/gobierto_budgets/ui.js
@@ -55,7 +55,7 @@ $(function(){
     groupBy: 'category'
   };
 
-  $('.search_auto').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, searchOptions));
+  $('.search_auto').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), searchOptions));
   $('.global .ham .fa-bars').click(function(e){
     e.preventDefault();
     $('.global .desktop').toggle();
@@ -68,7 +68,7 @@ $(function(){
       window.location.href = suggestion.data.url;
     }
   };
-  $searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, searchCategoriesOptions));
+  $searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), searchCategoriesOptions));
 
   $searchBudget = $('.search_categories_budget-income');
   searchCategoriesOptions = {
@@ -77,7 +77,7 @@ $(function(){
       window.location.href = suggestion.data.url;
     }
   };
-  $searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, searchCategoriesOptions));
+  $searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), searchCategoriesOptions));
 
   $('.sticky').sticky({topSpacing:0});
 

--- a/app/views/gobierto_budgets/pages/_compare_big.html.erb
+++ b/app/views/gobierto_budgets/pages/_compare_big.html.erb
@@ -65,7 +65,7 @@ var searchOptions = {
   groupBy: 'category'
 };
 
-$('.search_compare').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, searchOptions));
+$('.search_compare').autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), searchOptions));
 
 $('#compare_form').on('submit', function(e){
   e.preventDefault();

--- a/app/views/gobierto_budgets/places/show.js.erb
+++ b/app/views/gobierto_budgets/places/show.js.erb
@@ -16,5 +16,5 @@ var searchCategoriesOptions = {
     window.location.href = suggestion.data.url;
   }
 };
-$searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS, searchCategoriesOptions));
+$searchBudget.autocomplete($.extend({}, AUTOCOMPLETE_DEFAULTS(), searchCategoriesOptions));
 

--- a/config/locales/views/ca.yml
+++ b/config/locales/views/ca.yml
@@ -43,6 +43,7 @@ ca:
     configuration: Configuració
     sections: Seccions
     search: Cercar
+    autocomplete_no_results: 'Ho sentim, però no hi ha resultats'
   admin:
     registered_users:
       one: 1 usuari registrat

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -45,6 +45,7 @@ en:
     sections: Sections
     search: Search
     news: News
+    autocomplete_no_results: 'Sorry, but there are no results'
   admin:
     registered_users:
       one: 1 registered user

--- a/config/locales/views/es.yml
+++ b/config/locales/views/es.yml
@@ -44,6 +44,7 @@ es:
     sections: Secciones
     search: Buscar
     news: Novedades
+    autocomplete_no_results: 'Lo sentimos, pero no hay resultados.'
   admin:
     registered_users:
       one: 1 usuario registrado

--- a/config/locales/views/gobierto_budgets/ca.yml
+++ b/config/locales/views/gobierto_budgets/ca.yml
@@ -100,7 +100,7 @@ ca:
         budget_lines_income_lower: Partides d'ingressos molt inferiors al pressupost
         budget_lines_expense_higher: Partides de despeses molt superiors al pressupost
         budget_lines_expense_lower: Partides de despeses molt inferiors al pressupost
-        no_data: "No hi ha dades disponibles en %{year}, per tant te mostrarem el primer any amb dades"
+        no_data: "No hi ha dades disponibles en %{year}, per tant et mostrarem el primer any amb dades"
       execution_table:
         planned: Plan.
         executed: Execució


### PR DESCRIPTION
This PR localizes the sentence for the autosuggest and fixes a typo.

Related with:

https://github.com/PopulateTools/gobierto-budgets-comparator-gen-cat/issues/40#issuecomment-266469775