### PR TITLE
Show a full screen overlay while loading new data

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/maps.js
+++ b/app/assets/javascripts/gobierto_budgets/maps.js
@@ -39,6 +39,10 @@ $(function () {
 
   function renderMapIndicator(layer, vis){
     $('[data-indicator]').click(function(e){
+      $('#map .fullscreen-spinner').css({
+        'opacity': '1'
+      });
+      
       $('.cartodb-tooltip').hide();
       var year = $('body').data('year');
       var indicator = $('.metric.selected').data('indicator');
@@ -91,6 +95,10 @@ $(function () {
             var c = $('<div class="quartile" style="background-color:'+color+'"></div>');
             lc.find('.colors').append(c);
           });
+          
+          $('#map .fullscreen-spinner').css({
+            'opacity': '0'
+          });
         })
       .error(function(errors) {
         console.log("errors:" + errors);
@@ -100,6 +108,10 @@ $(function () {
 
   function renderMapBudgetLine(layer, vis){
     $(document).on('renderBudgetLineCategory', function(e){
+      $('#map .fullscreen-spinner').css({
+        'opacity': '1'
+      });
+      
       $('.cartodb-tooltip').hide();
       $('.metric').removeClass('selected');
       var year = $('body').data('year');
@@ -147,6 +159,10 @@ $(function () {
           colors.forEach(function(color){
             var c = $('<div class="quartile" style="background-color:'+color+'"></div>');
             lc.find('.colors').append(c);
+          });
+          
+          $('#map .fullscreen-spinner').css({
+            'opacity': '0'
           });
         })
         .error(function(errors) {

--- a/app/assets/javascripts/gobierto_budgets/maps.js
+++ b/app/assets/javascripts/gobierto_budgets/maps.js
@@ -39,8 +39,13 @@ $(function () {
 
   function renderMapIndicator(layer, vis){
     $('[data-indicator]').click(function(e){
-      $('#map .fullscreen-spinner').css({
-        'opacity': '1'
+      $('#map .overlay').css({
+        'display': 'block'
+      });
+      
+      $('#map .cartodb-tiles-loader').css({
+        'position': 'relative',
+        'z-index': '-1'
       });
       
       $('.cartodb-tooltip').hide();
@@ -95,10 +100,6 @@ $(function () {
             var c = $('<div class="quartile" style="background-color:'+color+'"></div>');
             lc.find('.colors').append(c);
           });
-          
-          $('#map .fullscreen-spinner').css({
-            'opacity': '0'
-          });
         })
       .error(function(errors) {
         console.log("errors:" + errors);
@@ -108,8 +109,13 @@ $(function () {
 
   function renderMapBudgetLine(layer, vis){
     $(document).on('renderBudgetLineCategory', function(e){
-      $('#map .fullscreen-spinner').css({
-        'opacity': '1'
+      $('#map .overlay').css({
+        'display': 'block'
+      });
+      
+      $('#map .cartodb-tiles-loader').css({
+        'position': 'relative',
+        'z-index': '-1'
       });
       
       $('.cartodb-tooltip').hide();
@@ -160,10 +166,6 @@ $(function () {
             var c = $('<div class="quartile" style="background-color:'+color+'"></div>');
             lc.find('.colors').append(c);
           });
-          
-          $('#map .fullscreen-spinner').css({
-            'opacity': '0'
-          });
         })
         .error(function(errors) {
           console.log("errors:" + errors);
@@ -200,17 +202,17 @@ $(function () {
     };
 
     cartodb.createVis('map', 'https://gobierto.carto.com/api/v2/viz/205616b2-b893-11e6-b070-0e233c30368f/viz.json', {
-        shareable: false,
-        title: false,
-        description: false,
-        search: false,
-        tiles_loader: true,
-        center_lat: window.mapSettings.centerLat,
-        center_lon: window.mapSettings.centerLon,
-        zoom: window.mapSettings.zoomLevel,
-        zoomControl: true,
-        loaderControl: true
-        })
+      shareable: false,
+      title: false,
+      description: false,
+      search: false,
+      tiles_loader: true,
+      center_lat: window.mapSettings.centerLat,
+      center_lon: window.mapSettings.centerLon,
+      zoom: window.mapSettings.zoomLevel,
+      zoomControl: true,
+      loaderControl: true
+    })
     .done(function(vis, layers) {
       var sublayer = layers[1].getSubLayer(0);
       vis.addOverlay({
@@ -224,6 +226,18 @@ $(function () {
       renderMapIndicator(sublayer, vis);
       renderMapBudgetLine(sublayer, vis);
       $('[data-indicator].selected').click();
+      
+      // On load, hide the overlay and reset the tile spinner
+      layers[1].on("load", function() {
+        $('#map .overlay').css({
+          'display': 'none'
+        });
+        
+        $('#map .cartodb-tiles-loader').css({
+          'position': 'initial',
+          'z-index': '0'
+        });
+      });
     })
     .error(function(err) {
       console.log(err);

--- a/app/assets/stylesheets/gobierto_budgets/map_page.scss
+++ b/app/assets/stylesheets/gobierto_budgets/map_page.scss
@@ -14,6 +14,15 @@ header .year_switcher ul {
   transition: none;
 }
 
+// Metrics
+body[data-action="map"] .main_metrics .metric {
+  transition: all 0.15s ease-out 0s;
+}
+body[data-action="map"] .main_metrics .metric:hover {
+  background: #a5d8dd;
+  cursor: pointer;
+}
+
 // Move zoom control buttons
 .cartodb-map-wrapper .cartodb-zoom {
   float: right;
@@ -26,6 +35,17 @@ header .year_switcher ul {
   margin: 0 20px 0 0;
 }
 
+// Full screen spinner
+.fullscreen-spinner {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.15);
+  transition: all 0.5s ease-out 0s;
+  z-index: 1;
+}
 
 // Sidebar
 .map_sidebar {

--- a/app/assets/stylesheets/gobierto_budgets/map_page.scss
+++ b/app/assets/stylesheets/gobierto_budgets/map_page.scss
@@ -34,17 +34,24 @@ body[data-action="map"] .main_metrics .metric:hover {
   float: right;
   margin: 0 20px 0 0;
 }
-
-// Full screen spinner
-.fullscreen-spinner {
-  position: absolute;
+#map .overlay {
   pointer-events: none;
-  opacity: 0;
-  width: 100%;
+  position: absolute;
   height: 100%;
-  background: rgba(0, 0, 0, 0.15);
-  transition: all 0.5s ease-out 0s;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.25);
+  display: none;
   z-index: 1;
+}
+#map .fa-spin {
+  position: absolute;
+  top: 45%;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  color: #fff;
 }
 
 // Sidebar

--- a/app/views/gobierto_budgets/pages/map.html.erb
+++ b/app/views/gobierto_budgets/pages/map.html.erb
@@ -56,6 +56,7 @@
 
 <div id="map">
   <div id="legend-container" class="cartodb-legend-stack"></div>
+  <div class="fullscreen-spinner"></div>
 </div>
 
 

--- a/app/views/gobierto_budgets/pages/map.html.erb
+++ b/app/views/gobierto_budgets/pages/map.html.erb
@@ -55,8 +55,10 @@
 </div>
 
 <div id="map">
+  <div class="overlay">
+    <i class="fa fa-refresh fa-spin fa-5x fa-fw"></i>
+  </div>
   <div id="legend-container" class="cartodb-legend-stack"></div>
-  <div class="fullscreen-spinner"></div>
 </div>
 
 


### PR DESCRIPTION
This PR fixes #24, creating an overlay spinner that is fired every time the user loads a new dataset, but not while zooming or panning.

It also styles the map metrics indicators while hovering.